### PR TITLE
Id de raspberry incluido y automatizado

### DIFF
--- a/app24_1.js
+++ b/app24_1.js
@@ -29,6 +29,7 @@ const { parseSSID, parseType, parseFreq } = require("./functions");
 var timestamp = new Date();
 
 let wifidata = {}
+wifidata.id = process.env.id
 
 function init() {
   console.log("iniciando capturas...");

--- a/app24_11.js
+++ b/app24_11.js
@@ -28,6 +28,7 @@ const { parseSSID, parseType, parseFreq } = require("./functions");
 var timestamp = new Date();
 
 let wifidata = {}
+wifidata.id = process.env.id
 
 function init() {
   console.log("iniciando capturas...");

--- a/app24_6.js
+++ b/app24_6.js
@@ -29,6 +29,7 @@ const { parseSSID, parseType, parseFreq } = require("./functions");
 var timestamp = new Date();
 
 let wifidata = {}
+wifidata.id = process.env.id
 
 function init() {
   console.log("iniciando capturas...");

--- a/appBLE.js
+++ b/appBLE.js
@@ -1,4 +1,5 @@
 const { SerialPort, ReadlineParser } = require('serialport')
+require("dotenv").config();
 const Database = require("better-sqlite3");
 const mqtt = require("mqtt")
 
@@ -56,6 +57,7 @@ encoding:'hex'}))
 let chain = ''
 
 let dato = {}
+dato.idRasp = process.env.id
 
 parser.on('data',function(buff){
     //console.log(buff.toString('hex'))

--- a/chan_assign2.sh
+++ b/chan_assign2.sh
@@ -3,8 +3,17 @@
 # Codigo encargado de configurar las terminales Wifi. En nuestro caso queremos valores fijos por lo que es más sencillo.
 # Ejecutar antes este script para configurar las interfaces.
 
-rm ../.env
+rm .env
 ipint="192.168.102.143" # Hay que editar esta variable para que funcione
+hostname="Raspberry1"
+old_host=$(cat /etc/hostname)
+echo $hostname > /etc/hostname
+
+if [[ $old_host != $hostname ]]
+then
+        echo "127.0.1.1 "$hostname >>/etc/hosts
+        echo "New hostname assigned"
+fi
 
 iface1=''
 iface2=''
@@ -108,9 +117,10 @@ echo $iface1
 echo $iface2
 echo $iface3
 
-echo "iface1="$iface1 >> ../.env
-echo "iface2="$iface2 >> ../.env
-echo "iface3="$iface3 >> ../.env
+echo "iface1="$iface1 >> .env
+echo "iface2="$iface2 >> .env
+echo "iface3="$iface3 >> .env
+echo "id="$hostname >> .env
 
 sleep 1
 echo "bajando interfaces wifi $iface1, $iface2, $iface3"

--- a/script_chans/chan_assign2.sh
+++ b/script_chans/chan_assign2.sh
@@ -3,7 +3,7 @@
 # Codigo encargado de configurar las terminales Wifi. En nuestro caso queremos valores fijos por lo que es más sencillo.
 # Ejecutar antes este script para configurar las interfaces.
 
-rm ../.env
+rm .env
 ipint="192.168.102.143" # Hay que editar esta variable para que funcione
 
 iface1=''
@@ -106,9 +106,9 @@ echo $iface1
 echo $iface2
 echo $iface3
 
-echo "iface1="$iface1 >> ../.env
-echo "iface2="$iface2 >> ../.env
-echo "iface3="$iface3 >> ../.env
+echo "iface1="$iface1 >> .env
+echo "iface2="$iface2 >> .env
+echo "iface3="$iface3 >> .env
 
 sleep 1
 echo "bajando interfaces wifi $iface1, $iface2, $iface3"


### PR DESCRIPTION
Las raspberry necesitan enviar identificador al server para que a posteriori se sepa cual es cual, he puesto en el script sh que puedas darle uno, ese identificador te aparece al hacer ssh y creo que incluso en el nomachine, de momento solo la he probado en la Raspberry5 tengo que actualizar las otras

Para hacer funcionar el código primero modifica chan_assign2.sh el que está en la carpeta junto a los scripts de js, asigna la IP y hostname y luego ejecutalo con sudo pm2 start

![imagen](https://user-images.githubusercontent.com/79535205/174136524-be7f3393-8d37-4df5-8fb0-9a0011b69b35.png)
